### PR TITLE
enable history mode for router to remove the #

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -41,7 +41,10 @@ export default (store) => {
     }
   ]
 
-  const router = new Router({routes})
+  const router = new Router({
+    mode: 'history',
+    routes
+  })
 
   router.beforeEach((to, from, next) => {
     // when account credentials are passed as query


### PR DESCRIPTION
this enabled urls like `http://localhost:8080/buy` instead of `http://localhost:8080/#/buy`

but it needs some redirects on the webserver to directly access subfolders, see: `https://router.vuejs.org/en/essentials/history-mode.html`

This is needed because the shorturls redirect to https://beer.aepps.com/?p=...